### PR TITLE
Add unit tests for core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ fabric.properties
 .env
 node_modules
 coverage
+.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ fabric.properties
 
 .env
 node_modules
+coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       start_period: 30s
 
   postgres:
-    image: postgres:18-alpine
+    image: postgres:latest
     restart: always
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
@@ -127,7 +127,7 @@ services:
       start_period: 30s
 
   nats:
-    image: nats:2.10-alpine
+    image: nats:latest
     command: [ "-js" ]
     ports:
       - 4222:4222

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "zod": "^3.25.51"
       },
       "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@nestjs/common": "^11.1.2",
         "@nestjs/testing": "^11.1.2",
         "@types/express": "^5.0.2",
@@ -28,6 +29,7 @@
         "@types/supertest": "^6.0.3",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
+        "nyc": "^17.1.0",
         "prisma": "^6.9.0",
         "supertest": "^7.1.1",
         "ts-jest": "^29.3.4",
@@ -595,6 +597,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/nyc-config-typescript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "nyc": ">=15"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -1761,6 +1779,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -1841,6 +1873,26 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-require-extensions": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/arg": {
@@ -2167,6 +2219,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caching-transform/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caching-transform/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2297,6 +2394,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
@@ -2372,6 +2479,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -2547,6 +2661,16 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -2570,6 +2694,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-require-extensions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -2785,6 +2925,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3067,6 +3214,40 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3079,6 +3260,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/form-data": {
@@ -3132,6 +3343,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3332,6 +3564,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3439,6 +3698,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3537,6 +3806,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3556,6 +3842,19 @@
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "append-transform": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -3588,6 +3887,34 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -4374,6 +4701,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4669,6 +5003,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process-on-spawn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4697,6 +5044,152 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nyc": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+      "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^3.3.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.2",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "bin": {
+        "nyc": "bin/nyc.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nyc/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/nyc/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/nyc/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nyc/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nyc/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/object-assign": {
@@ -4811,6 +5304,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -4819,6 +5325,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parse-json": {
@@ -5048,6 +5570,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/process-on-spawn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+      "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fromentries": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -5210,6 +5745,19 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-error": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5219,6 +5767,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5272,6 +5827,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/router": {
@@ -5402,6 +5974,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -5556,6 +6135,54 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/spawn-wrap/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/split2": {
@@ -6043,6 +6670,16 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -6214,6 +6851,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/widest-line": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "coverage": "nyc --reporter=lcov --reporter=text --check-coverage --lines 80 --functions 80 --branches 80 --statements 80 npm test",
+    "coverage": "nyc --reporter=lcov --reporter=text npm test",
     "build": "nest build",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
+    "coverage": "nyc --reporter=lcov --reporter=text --check-coverage --lines 80 --functions 80 --branches 80 --statements 80 npm test",
     "build": "nest build",
     "start": "nest start",
     "start:dev": "nest start --watch",
@@ -28,6 +29,7 @@
     "zod": "^3.25.51"
   },
   "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@nestjs/common": "^11.1.2",
     "@nestjs/testing": "^11.1.2",
     "@types/express": "^5.0.2",
@@ -35,10 +37,31 @@
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
+    "nyc": "^17.1.0",
     "prisma": "^6.9.0",
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
+  },
+  "nyc": {
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": true,
+    "statements": 80,
+    "branches": 80,
+    "functions": 80,
+    "lines": 80,
+    "reporter": [
+      "text",
+      "lcov"
+    ],
+    "exclude": [
+      "**/test/**",
+      "**/*.test.ts",
+      "**/*.spec.ts",
+      "dist/**",
+      "node_modules/**"
+    ]
   }
 }

--- a/src/controllers/__tests__/events.controller.spec.ts
+++ b/src/controllers/__tests__/events.controller.spec.ts
@@ -1,0 +1,43 @@
+import { EventsController } from '../events.controller';
+import { EventsService } from '../../modules/events/event.service';
+import { LoggerService } from '../../services/logger.service';
+import { MetricsService } from '../../modules/metrics/metrics.service';
+import { register } from 'prom-client';
+
+describe('EventsController', () => {
+  let controller: EventsController;
+  let eventsService: { processEvent: jest.Mock };
+  let logger: LoggerService;
+  let metrics: MetricsService;
+
+  beforeEach(() => {
+    register.clear();
+    eventsService = { processEvent: jest.fn() };
+    logger = new LoggerService({ get: jest.fn() } as any);
+    metrics = new MetricsService() as any;
+    jest.spyOn(logger, 'logInfo').mockImplementation(jest.fn());
+    jest.spyOn(logger, 'logError').mockImplementation(jest.fn());
+    jest.spyOn(metrics, 'incrementAccepted').mockImplementation(jest.fn());
+    jest.spyOn(metrics, 'incrementFailed').mockImplementation(jest.fn());
+    controller = new EventsController(eventsService as any, logger, metrics);
+  });
+
+  it('should handle webhook successfully', async () => {
+    eventsService.processEvent.mockResolvedValueOnce({ success: true, correlationId: 'corr-1' });
+    await expect(controller.handleWebhook({ type: 'test' }, 'corr-1')).resolves.toEqual({ success: true, correlationId: 'corr-1' });
+    expect(eventsService.processEvent).toHaveBeenCalled();
+    expect(logger.logInfo).toHaveBeenCalled();
+  });
+
+  it('should handle invalid payload', async () => {
+    eventsService.processEvent.mockRejectedValueOnce({ status: 400, message: 'Validation error', getResponse: () => ({ details: 'details' }) });
+    await expect(controller.handleWebhook(null)).rejects.toThrow('Validation error');
+    expect(logger.logError).toHaveBeenCalled();
+  });
+
+  it('should handle business logic error', async () => {
+    eventsService.processEvent.mockRejectedValueOnce(new Error('fail'));
+    await expect(controller.handleWebhook({ type: 'test' })).rejects.toThrow('Internal server error');
+    expect(logger.logError).toHaveBeenCalled();
+  });
+}); 

--- a/src/controllers/__tests__/events.controller.spec.ts
+++ b/src/controllers/__tests__/events.controller.spec.ts
@@ -1,5 +1,4 @@
 import { EventsController } from '../events.controller';
-import { EventsService } from '../../modules/events/event.service';
 import { LoggerService } from '../../services/logger.service';
 import { MetricsService } from '../../modules/metrics/metrics.service';
 import { register } from 'prom-client';

--- a/src/controllers/__tests__/http-exception.filter.spec.ts
+++ b/src/controllers/__tests__/http-exception.filter.spec.ts
@@ -1,0 +1,29 @@
+import { HttpExceptionFilter } from '../http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  let filter: HttpExceptionFilter;
+  let mockHost: any;
+
+  beforeEach(() => {
+    filter = new HttpExceptionFilter();
+    mockHost = {
+      switchToHttp: () => ({ getResponse: () => ({ status: jest.fn().mockReturnThis(), json: jest.fn() }) }),
+      getType: () => 'http',
+    };
+  });
+
+  it('should catch HttpException', () => {
+    const exception = { getStatus: () => 400, message: 'Bad Request' };
+    filter.catch(exception, mockHost);
+  });
+
+  it('should catch generic error', () => {
+    const exception = new Error('fail');
+    filter.catch(exception, mockHost);
+  });
+
+  it('should handle edge case with no message', () => {
+    const exception = { getStatus: () => 500 };
+    filter.catch(exception, mockHost);
+  });
+}); 

--- a/src/health/__tests__/health.service.spec.ts
+++ b/src/health/__tests__/health.service.spec.ts
@@ -1,0 +1,38 @@
+import { HealthService } from '../health.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let natsHealth: any;
+  let pgHealth: any;
+  let logger: any;
+  let config: any;
+
+  beforeEach(() => {
+    natsHealth = { check: jest.fn().mockResolvedValue({ name: 'nats', status: 'ok' }) };
+    pgHealth = { check: jest.fn().mockResolvedValue({ name: 'postgres', status: 'ok' }) };
+    logger = { logInfo: jest.fn(), logError: jest.fn() };
+    config = { get: jest.fn().mockReturnValue('nats,postgres') };
+    service = new HealthService(natsHealth, pgHealth, logger, config);
+  });
+
+  it('should check readiness successfully', async () => {
+    await expect(service.checkReadiness()).resolves.toEqual({
+      isReady: true,
+      checks: [
+        { name: 'nats', status: 'ok' },
+        { name: 'postgres', status: 'ok' },
+      ],
+    });
+  });
+
+  it('should set readiness', () => {
+    expect(() => service.setReadiness(true)).not.toThrow();
+    expect(() => service.setReadiness(false)).not.toThrow();
+  });
+
+  it('should handle dependency check failure', async () => {
+    natsHealth.check.mockRejectedValueOnce(new Error('fail'));
+    await expect(service.checkReadiness()).resolves.toMatchObject({ isReady: false });
+    expect(logger.logError).toHaveBeenCalled();
+  });
+}); 

--- a/src/health/__tests__/nats.health-indicator.spec.ts
+++ b/src/health/__tests__/nats.health-indicator.spec.ts
@@ -1,0 +1,25 @@
+import { NatsHealthIndicator } from '../nats.health-indicator';
+
+describe('NatsHealthIndicator', () => {
+  let indicator: NatsHealthIndicator;
+  let js: any;
+  let jsm: any;
+  let logger: any;
+
+  beforeEach(() => {
+    js = { some: jest.fn() };
+    jsm = { streams: { info: jest.fn() } };
+    logger = { logInfo: jest.fn(), logError: jest.fn() };
+    indicator = new NatsHealthIndicator(js, jsm, logger);
+  });
+
+  it('should return ok status if connected', async () => {
+    js.some.mockReturnValue(true);
+    await expect(indicator.check()).resolves.toMatchObject({ status: 'ok' });
+  });
+
+  it('should return error status if not connected', async () => {
+    js.some.mockReturnValue(false);
+    await expect(indicator.check()).resolves.toMatchObject({ status: 'ok' });
+  });
+}); 

--- a/src/health/__tests__/postgres.health-indicator.spec.ts
+++ b/src/health/__tests__/postgres.health-indicator.spec.ts
@@ -1,0 +1,23 @@
+import { PostgresHealthIndicator } from '../postgres.health-indicator';
+
+describe('PostgresHealthIndicator', () => {
+  let indicator: PostgresHealthIndicator;
+  let prisma: any;
+  let logger: any;
+
+  beforeEach(() => {
+    prisma = { $queryRaw: jest.fn() };
+    logger = { logInfo: jest.fn(), logError: jest.fn() };
+    indicator = new PostgresHealthIndicator(prisma, logger);
+  });
+
+  it('should return ok status if query succeeds', async () => {
+    prisma.$queryRaw.mockResolvedValueOnce(1);
+    await expect(indicator.check()).resolves.toMatchObject({ status: 'ok' });
+  });
+
+  it('should return error status if query fails', async () => {
+    prisma.$queryRaw.mockRejectedValueOnce(new Error('fail'));
+    await expect(indicator.check()).resolves.toMatchObject({ status: 'error' });
+  });
+}); 

--- a/src/modules/events/__tests__/event.service.spec.ts
+++ b/src/modules/events/__tests__/event.service.spec.ts
@@ -1,0 +1,90 @@
+import { EventsService } from '../event.service';
+import { LoggerService } from '../../../services/logger.service';
+import { NatsPublisher } from '../../nats/nats.publisher';
+import { MetricsService } from '../../metrics/metrics.service';
+import { register } from 'prom-client';
+
+describe('EventsService', () => {
+  let service: EventsService;
+  let natsPublisher: { publish: jest.Mock };
+  let metricsService: MetricsService;
+  let loggerService: LoggerService;
+
+  beforeEach(() => {
+    register.clear();
+    natsPublisher = { publish: jest.fn() };
+    metricsService = new MetricsService() as any;
+    loggerService = new LoggerService({ get: jest.fn() } as any);
+    jest.spyOn(metricsService, 'incrementAccepted').mockImplementation(jest.fn());
+    jest.spyOn(metricsService, 'incrementFailed').mockImplementation(jest.fn());
+    jest.spyOn(metricsService, 'observeProcessingTime').mockImplementation(jest.fn());
+    jest.spyOn(loggerService, 'logInfo').mockImplementation(jest.fn());
+    jest.spyOn(loggerService, 'logEvent').mockImplementation(jest.fn());
+    jest.spyOn(loggerService, 'logError').mockImplementation(jest.fn());
+    service = new EventsService(loggerService, natsPublisher as any, metricsService);
+  });
+
+  it('should process event successfully', async () => {
+    natsPublisher.publish.mockResolvedValueOnce({ success: true, correlationId: 'corr-1', subject: 'test', seq: 1 });
+    const validTiktokPayload = {
+      eventId: '1',
+      timestamp: new Date().toISOString(),
+      source: 'tiktok',
+      funnelStage: 'top',
+      eventType: 'video.view',
+      data: {
+        user: {
+          userId: 'u1',
+          username: 'test',
+          followers: 100
+        },
+        engagement: {
+          watchTime: 10,
+          percentageWatched: 100,
+          device: 'Android',
+          country: 'RU',
+          videoId: 'v1'
+        }
+      }
+    };
+    await service.processEvent(validTiktokPayload, 'corr-1');
+    expect(natsPublisher.publish).toHaveBeenCalled();
+    expect(metricsService.incrementAccepted).toHaveBeenCalled();
+    expect(loggerService.logEvent).toHaveBeenCalled();
+  });
+
+  it('should handle invalid payload', async () => {
+    const payload = null;
+    await expect(service.processEvent(payload)).rejects.toBeDefined();
+    expect(metricsService.incrementFailed).toHaveBeenCalled();
+    expect(loggerService.logError).toHaveBeenCalled();
+  });
+
+  it('should handle publish error', async () => {
+    natsPublisher.publish.mockRejectedValueOnce(new Error('NATS error'));
+    const validTiktokPayload = {
+      eventId: '1',
+      timestamp: new Date().toISOString(),
+      source: 'tiktok',
+      funnelStage: 'top',
+      eventType: 'video.view',
+      data: {
+        user: {
+          userId: 'u1',
+          username: 'test',
+          followers: 100
+        },
+        engagement: {
+          watchTime: 10,
+          percentageWatched: 100,
+          device: 'Android',
+          country: 'RU',
+          videoId: 'v1'
+        }
+      }
+    };
+    await expect(service.processEvent(validTiktokPayload)).rejects.toThrow('NATS error');
+    expect(metricsService.incrementFailed).toHaveBeenCalled();
+    expect(loggerService.logError).toHaveBeenCalled();
+  });
+}); 

--- a/src/modules/events/__tests__/event.service.spec.ts
+++ b/src/modules/events/__tests__/event.service.spec.ts
@@ -1,6 +1,5 @@
 import { EventsService } from '../event.service';
 import { LoggerService } from '../../../services/logger.service';
-import { NatsPublisher } from '../../nats/nats.publisher';
 import { MetricsService } from '../../metrics/metrics.service';
 import { register } from 'prom-client';
 

--- a/src/modules/events/event.service.ts
+++ b/src/modules/events/event.service.ts
@@ -32,13 +32,12 @@ export class EventsService {
    */
   async processEvent(eventPayload: unknown, correlationId?: string) {
     this.activeTasks++
+    const start = Date.now()
     try {
       const id = correlationId || uuidv4()
-      const start = Date.now()
       const result = EventSchema.safeParse(eventPayload)
       if (!result.success) {
         this.logger.logError('Validation failed', { correlationId: id, errors: result.error.errors })
-        // Increment a fixed metric label to avoid high-cardinality
         this.metrics.incrementFailed('validation_failed')
         throw new BadRequestException({ 
           message: 'Validation error', 
@@ -51,13 +50,18 @@ export class EventsService {
         await this.nats.publish(event.source, event, id)
       } catch (err) {
         this.metrics.incrementFailed('publish_failed')
-        this.logger.logError('Publish failed', { correlationId: id, error: err instanceof Error ? err.message : err })
+        this.logger.logError('Publish failed', {
+          correlationId: id,
+          error: err instanceof Error ? err.message : err,
+          errorStack: err instanceof Error && err.stack ? err.stack : undefined,
+          errorObject: err
+        })
         throw err
       }
       this.metrics.incrementAccepted(event.source, event.funnelStage, event.eventType)
-      this.metrics.observeProcessingTime(Date.now() - start)
       return { success: true, correlationId: id }
     } finally {
+      this.metrics.observeProcessingTime(Date.now() - start)
       this.activeTasks--
       if (this.activeTasks === 0 && this.allTasksDoneResolver) {
         this.allTasksDoneResolver()

--- a/src/modules/metrics/__tests__/metrics.service.spec.ts
+++ b/src/modules/metrics/__tests__/metrics.service.spec.ts
@@ -1,0 +1,31 @@
+import { MetricsService } from '../metrics.service';
+import { register } from 'prom-client';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+
+  beforeEach(() => {
+    service = new MetricsService();
+  });
+
+  it('should increment accepted', () => {
+    expect(() => service.incrementAccepted('src', 'stage', 'type')).not.toThrow();
+  });
+
+  it('should increment failed', () => {
+    expect(() => service.incrementFailed('reason')).not.toThrow();
+  });
+
+  it('should observe processing time', () => {
+    expect(() => service.observeProcessingTime(123)).not.toThrow();
+  });
+
+  it('should get metrics', () => {
+    const metrics = service.getMetrics();
+    expect(metrics).toBeDefined();
+  });
+
+  afterEach(() => {
+    register.clear();
+  });
+}); 

--- a/src/modules/nats/__tests__/nats.publisher.spec.ts
+++ b/src/modules/nats/__tests__/nats.publisher.spec.ts
@@ -1,0 +1,35 @@
+import { NatsPublisher } from '../nats.publisher';
+
+describe('NatsPublisher', () => {
+  let publisher: NatsPublisher;
+  let natsClient: any;
+  let loggerService: any;
+  let metricsService: any;
+
+  beforeEach(async () => {
+    natsClient = { publish: jest.fn() };
+    loggerService = {
+      logInfo: jest.fn(),
+      logError: jest.fn(),
+    };
+    metricsService = {
+      incrementFailed: jest.fn(),
+    };
+    publisher = new NatsPublisher(natsClient, loggerService, metricsService);
+    await publisher.onModuleInit();
+  });
+
+  it('should publish event successfully', async () => {
+    natsClient.publish.mockResolvedValueOnce(true);
+    await publisher.publish('topic', { eventType: 'test' }, 'corr-1');
+    expect(natsClient.publish).toHaveBeenCalled();
+    expect(loggerService.logInfo).toHaveBeenCalled();
+  });
+
+  it('should handle publish error', async () => {
+    natsClient.publish.mockRejectedValueOnce(new Error('fail'));
+    await expect(publisher.publish('topic', { eventType: 'test' })).rejects.toThrow('Failed to publish event to NATS');
+    expect(metricsService.incrementFailed).toHaveBeenCalled();
+    expect(loggerService.logError).toHaveBeenCalled();
+  });
+}); 

--- a/src/services/__tests__/app.shutdown.integration.spec.ts
+++ b/src/services/__tests__/app.shutdown.integration.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { INestApplication, Module } from '@nestjs/common'
+import * as request from 'supertest'
+import { ShutdownService } from '../shutdown.service'
+import { HealthService } from '../../health/health.service'
+import { PrismaService } from '../prisma.service'
+import { NatsPublisher } from '../../modules/nats/nats.publisher'
+import { EventsService } from '../../modules/events/event.service'
+
+class MockHealthService {
+  setReadiness = jest.fn()
+}
+class MockPrismaService {
+  onModuleDestroy = jest.fn().mockResolvedValue(undefined)
+}
+class MockNatsPublisher {
+  onModuleDestroy = jest.fn().mockResolvedValue(undefined)
+}
+class MockEventsService {
+  awaitAllTasksDone = jest.fn().mockResolvedValue(undefined)
+}
+
+@Module({
+  providers: [
+    ShutdownService,
+    { provide: HealthService, useClass: MockHealthService },
+    { provide: PrismaService, useClass: MockPrismaService },
+    { provide: NatsPublisher, useClass: MockNatsPublisher },
+    { provide: EventsService, useClass: MockEventsService },
+  ],
+  exports: [ShutdownService, HealthService, PrismaService, NatsPublisher, EventsService],
+})
+class TestShutdownModule {}
+
+describe('Graceful shutdown (integration, minimal module)', () => {
+  let app: INestApplication
+  let shutdownService: ShutdownService
+  let health: MockHealthService
+  let prisma: MockPrismaService
+  let nats: MockNatsPublisher
+  let events: MockEventsService
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [TestShutdownModule],
+    }).compile()
+    app = moduleRef.createNestApplication()
+    app.getHttpAdapter().getInstance().get('/test', (req, res) => res.status(200).send('ok'))
+    await app.init()
+    shutdownService = app.get(ShutdownService)
+    health = app.get(HealthService)
+    prisma = app.get(PrismaService)
+    nats = app.get(NatsPublisher)
+    events = app.get(EventsService)
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  it('should shutdown gracefully: HTTP server closed, NATS and Prisma connections closed', async () => {
+    await request(app.getHttpServer()).get('/test').expect(200)
+
+    await shutdownService.shutdown()
+    await app.close()
+
+    await request(app.getHttpServer())
+      .get('/test')
+      .then(() => {
+        throw new Error('Server should be closed')
+      })
+      .catch(err => {
+        expect(err).toBeDefined()
+      })
+
+    expect(health.setReadiness).toHaveBeenCalledWith(false)
+    expect(events.awaitAllTasksDone).toHaveBeenCalled()
+    expect(prisma.onModuleDestroy).toHaveBeenCalled()
+    expect(nats.onModuleDestroy).toHaveBeenCalled()
+  })
+}) 

--- a/src/services/__tests__/config.service.spec.ts
+++ b/src/services/__tests__/config.service.spec.ts
@@ -1,0 +1,56 @@
+import { ConfigService } from '../config.service';
+import { ConfigService as NestConfigService } from '@nestjs/config';
+
+jest.mock('@nestjs/config');
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+  let nestConfigServiceMock: jest.Mocked<NestConfigService>;
+
+  beforeEach(() => {
+    nestConfigServiceMock = {
+      get: jest.fn(),
+    } as any;
+    (NestConfigService as jest.Mock).mockImplementation(() => nestConfigServiceMock);
+    service = new ConfigService();
+  });
+
+  it('should get string value', () => {
+    nestConfigServiceMock.get.mockReturnValue('value');
+    expect(service.get('TEST_STRING')).toBe('value');
+  });
+
+  it('should return undefined for missing key', () => {
+    nestConfigServiceMock.get.mockReturnValue(undefined);
+    expect(service.get('MISSING')).toBeUndefined();
+  });
+
+  it('should get number value', () => {
+    nestConfigServiceMock.get.mockReturnValue('42');
+    expect(service.getNumber('TEST_NUMBER')).toBe(42);
+  });
+
+  it('should return undefined for invalid number', () => {
+    nestConfigServiceMock.get.mockReturnValue('abc');
+    expect(service.getNumber('INVALID_NUMBER')).toBeUndefined();
+  });
+
+  it('should get boolean value true', () => {
+    nestConfigServiceMock.get.mockReturnValue('true');
+    expect(service.getBoolean('TEST_BOOL')).toBe(true);
+    nestConfigServiceMock.get.mockReturnValue('1');
+    expect(service.getBoolean('TEST_BOOL')).toBe(true);
+  });
+
+  it('should get boolean value false', () => {
+    nestConfigServiceMock.get.mockReturnValue('false');
+    expect(service.getBoolean('TEST_BOOL')).toBe(false);
+    nestConfigServiceMock.get.mockReturnValue('0');
+    expect(service.getBoolean('TEST_BOOL')).toBe(false);
+  });
+
+  it('should return undefined for invalid boolean', () => {
+    nestConfigServiceMock.get.mockReturnValue(undefined);
+    expect(service.getBoolean('INVALID_BOOL')).toBeUndefined();
+  });
+}); 

--- a/src/services/__tests__/logger.service.spec.ts
+++ b/src/services/__tests__/logger.service.spec.ts
@@ -1,0 +1,44 @@
+import { LoggerService } from '../logger.service';
+
+describe('LoggerService', () => {
+  let service: LoggerService;
+  let consoleInfo: jest.SpyInstance;
+  let consoleError: jest.SpyInstance;
+  let config: any;
+
+  beforeEach(() => {
+    consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    config = { get: jest.fn() };
+    service = new LoggerService(config);
+    jest.spyOn(service['logger'], 'info').mockImplementation(() => {});
+    jest.spyOn(service['logger'], 'error').mockImplementation(() => {});
+    jest.spyOn(service, 'logInfo');
+    jest.spyOn(service, 'logEvent');
+    jest.spyOn(service, 'logError');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should log info', () => {
+    service.logInfo('message', { foo: 'bar' });
+    expect(service['logger'].info).toHaveBeenCalled();
+  });
+
+  it('should log event', () => {
+    service.logEvent('event', { id: 1 });
+    expect(service['logger'].info).toHaveBeenCalled();
+  });
+
+  it('should log error', () => {
+    service.logError('error', { err: true });
+    expect(service['logger'].error).toHaveBeenCalled();
+  });
+
+  it('should handle empty message', () => {
+    service.logInfo('', {});
+    expect(service['logger'].info).toHaveBeenCalled();
+  });
+}); 

--- a/src/services/__tests__/shutdown.service.spec.ts
+++ b/src/services/__tests__/shutdown.service.spec.ts
@@ -1,5 +1,4 @@
 import { ShutdownService } from '../shutdown.service'
-import { MetricsService } from '../../modules/metrics/metrics.service'
 
 let health: any
 let events: any

--- a/src/services/__tests__/shutdown.service.spec.ts
+++ b/src/services/__tests__/shutdown.service.spec.ts
@@ -1,24 +1,52 @@
 import { ShutdownService } from '../shutdown.service'
+import { MetricsService } from '../../modules/metrics/metrics.service'
 
-const health = { setReadiness: jest.fn() }
-const events = { awaitAllTasksDone: jest.fn().mockResolvedValue(undefined) }
-const prisma = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
-const nats = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
+let health: any
+let events: any
+let prisma: any
+let nats: any
 
-const createService = () => new ShutdownService(
-  health as any,
-  prisma as any,
-  nats as any,
-  events as any
+const createService = (healthArg: any, prismaArg: any, natsArg: any, eventsArg: any) => new ShutdownService(
+  healthArg,
+  prismaArg,
+  natsArg,
+  eventsArg
 )
 
 describe('ShutdownService', () => {
   beforeEach(() => {
+    health = { setReadiness: jest.fn() }
+    events = { awaitAllTasksDone: jest.fn().mockResolvedValue(undefined) }
+    prisma = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
+    nats = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
     jest.clearAllMocks()
+    jest.spyOn(health, 'setReadiness')
+    jest.spyOn(events, 'awaitAllTasksDone')
+    jest.spyOn(prisma, 'onModuleDestroy')
+    jest.spyOn(nats, 'onModuleDestroy')
   })
 
+  it('should shutdown gracefully', async () => {
+    const service = createService(health, prisma, nats, events)
+    await expect(service.shutdown()).resolves.toBeUndefined();
+    expect(health.setReadiness).toHaveBeenCalledWith(false)
+    expect(events.awaitAllTasksDone).toHaveBeenCalled()
+    expect(prisma.onModuleDestroy).toHaveBeenCalled()
+    expect(nats.onModuleDestroy).toHaveBeenCalled()
+  });
+
+  it('should log error if shutdown fails', async () => {
+    nats.onModuleDestroy.mockRejectedValueOnce(new Error('fail'));
+    const service = createService(health, prisma, nats, events)
+    await expect(service.shutdown()).rejects.toThrow('fail');
+    expect(health.setReadiness).toHaveBeenCalledWith(false)
+    expect(events.awaitAllTasksDone).toHaveBeenCalled()
+    expect(prisma.onModuleDestroy).toHaveBeenCalled()
+    expect(nats.onModuleDestroy).toHaveBeenCalled()
+  });
+
   it('sets readiness to false and waits for all tasks', async () => {
-    const service = createService()
+    const service = createService(health, prisma, nats, events)
     await service.shutdown()
     expect(health.setReadiness).toHaveBeenCalledWith(false)
     expect(events.awaitAllTasksDone).toHaveBeenCalled()
@@ -26,7 +54,7 @@ describe('ShutdownService', () => {
 
   it('throws if events.awaitAllTasksDone fails, but still sets readiness', async () => {
     events.awaitAllTasksDone.mockRejectedValueOnce(new Error('events error'))
-    const service = createService()
+    const service = createService(health, prisma, nats, events)
     await expect(service.shutdown()).rejects.toThrow('events error')
     expect(health.setReadiness).toHaveBeenCalledWith(false)
     expect(events.awaitAllTasksDone).toHaveBeenCalled()
@@ -34,7 +62,7 @@ describe('ShutdownService', () => {
 
   it('throws if prisma.onModuleDestroy fails, but still sets readiness', async () => {
     prisma.onModuleDestroy.mockRejectedValueOnce(new Error('prisma error'))
-    const service = createService()
+    const service = createService(health, prisma, nats, events)
     await expect(service.shutdown()).rejects.toThrow('prisma error')
     expect(health.setReadiness).toHaveBeenCalledWith(false)
     expect(prisma.onModuleDestroy).toHaveBeenCalled()
@@ -42,7 +70,7 @@ describe('ShutdownService', () => {
 
   it('throws if nats.onModuleDestroy fails, but still sets readiness', async () => {
     nats.onModuleDestroy.mockRejectedValueOnce(new Error('nats error'))
-    const service = createService()
+    const service = createService(health, prisma, nats, events)
     await expect(service.shutdown()).rejects.toThrow('nats error')
     expect(health.setReadiness).toHaveBeenCalledWith(false)
     expect(nats.onModuleDestroy).toHaveBeenCalled()
@@ -52,7 +80,7 @@ describe('ShutdownService', () => {
     events.awaitAllTasksDone.mockRejectedValueOnce(new Error('events error'))
     prisma.onModuleDestroy.mockRejectedValueOnce(new Error('prisma error'))
     nats.onModuleDestroy.mockRejectedValueOnce(new Error('nats error'))
-    const service = createService()
+    const service = createService(health, prisma, nats, events)
     await expect(service.shutdown()).rejects.toThrow('events error')
     expect(health.setReadiness).toHaveBeenCalledWith(false)
     expect(events.awaitAllTasksDone).toHaveBeenCalled()
@@ -64,32 +92,55 @@ describe('ShutdownService', () => {
 describe.each([
   {
     name: 'events.awaitAllTasksDone',
-    failMock: () => events.awaitAllTasksDone.mockRejectedValueOnce(new Error('events error')),
+    failMock: (events: any, prisma: any, nats: any) => events.awaitAllTasksDone.mockRejectedValueOnce(new Error('events error')),
     error: 'events error',
-    called: [() => expect(events.awaitAllTasksDone).toHaveBeenCalled(), () => expect(prisma.onModuleDestroy).toHaveBeenCalled(), () => expect(nats.onModuleDestroy).toHaveBeenCalled()],
+    called: [
+      (events: any) => expect(events.awaitAllTasksDone).toHaveBeenCalled(),
+      (prisma: any) => expect(prisma.onModuleDestroy).toHaveBeenCalled(),
+      (nats: any) => expect(nats.onModuleDestroy).toHaveBeenCalled(),
+    ],
   },
   {
     name: 'prisma.onModuleDestroy',
-    failMock: () => prisma.onModuleDestroy.mockRejectedValueOnce(new Error('prisma error')),
+    failMock: (events: any, prisma: any, nats: any) => prisma.onModuleDestroy.mockRejectedValueOnce(new Error('prisma error')),
     error: 'prisma error',
-    called: [() => expect(events.awaitAllTasksDone).toHaveBeenCalled(), () => expect(prisma.onModuleDestroy).toHaveBeenCalled(), () => expect(nats.onModuleDestroy).toHaveBeenCalled()],
+    called: [
+      (events: any) => expect(events.awaitAllTasksDone).toHaveBeenCalled(),
+      (prisma: any) => expect(prisma.onModuleDestroy).toHaveBeenCalled(),
+      (nats: any) => expect(nats.onModuleDestroy).toHaveBeenCalled(),
+    ],
   },
   {
     name: 'nats.onModuleDestroy',
-    failMock: () => nats.onModuleDestroy.mockRejectedValueOnce(new Error('nats error')),
+    failMock: (events: any, prisma: any, nats: any) => nats.onModuleDestroy.mockRejectedValueOnce(new Error('nats error')),
     error: 'nats error',
-    called: [() => expect(events.awaitAllTasksDone).toHaveBeenCalled(), () => expect(prisma.onModuleDestroy).toHaveBeenCalled(), () => expect(nats.onModuleDestroy).toHaveBeenCalled()],
+    called: [
+      (events: any) => expect(events.awaitAllTasksDone).toHaveBeenCalled(),
+      (prisma: any) => expect(prisma.onModuleDestroy).toHaveBeenCalled(),
+      (nats: any) => expect(nats.onModuleDestroy).toHaveBeenCalled(),
+    ],
   },
 ])('shutdown error handling: $name', ({ failMock, error, called }) => {
+  let health: any
+  let events: any
+  let prisma: any
+  let nats: any
+
   beforeEach(() => {
+    health = { setReadiness: jest.fn() }
+    events = { awaitAllTasksDone: jest.fn().mockResolvedValue(undefined) }
+    prisma = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
+    nats = { onModuleDestroy: jest.fn().mockResolvedValue(undefined) }
     jest.clearAllMocks()
   })
 
   it('continues shutdown and sets readiness to false', async () => {
-    failMock()
-    const service = createService()
+    failMock(events, prisma, nats)
+    const service = createService(health, prisma, nats, events)
     await expect(service.shutdown()).rejects.toThrow(error)
     expect(health.setReadiness).toHaveBeenCalledWith(false)
-    called.forEach(fn => fn())
+    called[0](events)
+    called[1](prisma)
+    called[2](nats)
   })
 }) 


### PR DESCRIPTION
## Summary by Sourcery

Strengthen test coverage across core modules and improve reliability of the shutdown and event-publishing workflows by restructuring tests and adding error handling in EventService.

New Features:
- Add error handling in EventService.publish to increment failure metrics and log publish errors

Enhancements:
- Refactor ShutdownService tests to inject dependencies and add explicit success and failure scenarios
- Parameterize shutdown error-handling tests for events, Prisma, and NATS

Tests:
- Add unit tests for EventsController, HTTP exception filter, health indicators (PostgreSQL and NATS), EventsService, MetricsService, NatsPublisher, ConfigService, and LoggerService