### PR TITLE
Implement batch event processing with DLQ

### DIFF
--- a/.env.example.development
+++ b/.env.example.development
@@ -5,3 +5,6 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=events
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/events
 LOG_LEVEL=info
+
+DLQ_PATH=./data/dead_letter_queue.jsonl
+LOG_LEVEL=info

--- a/src/modules/events/controllers/events.controller.ts
+++ b/src/modules/events/controllers/events.controller.ts
@@ -5,7 +5,6 @@ import { LoggerService } from '../../../common/services/logger.service'
 import { MetricsService } from '../../metrics/services/metrics.service'
 import { HttpExceptionFilter } from '../../../common/filters/http-exception.filter'
 import { HealthService } from '../../health/services/health.service'
-import { EventArraySchema } from '../dto/event.zod'
 import { EventStorageService } from '../services/event-storage.service'
 
 @ApiTags('Events')

--- a/src/modules/events/controllers/events.controller.ts
+++ b/src/modules/events/controllers/events.controller.ts
@@ -35,27 +35,6 @@ export class EventsController {
     if (this.healthService.isShuttingDownNow()) {
       throw new HttpException('Service is shutting down', HttpStatus.SERVICE_UNAVAILABLE)
     }
-    const parsed = EventArraySchema.safeParse(eventPayloads)
-    if (!parsed.success) {
-      this.metrics.incrementFailed('validation_failed')
-      const validationMessages = parsed.error.errors.map(
-        (err) => `${err.path.join('.')}: ${err.message}`
-      )
-      return [{ success: false, error: validationMessages }]
-    }
-    const results: { success: boolean; error?: any }[] = []
-    for (const event of parsed.data) {
-      try {
-        await this.eventStorage.add(event)
-        this.metrics.incrementAccepted(event.source, event.funnelStage, event.eventType)
-        results.push({ success: true })
-      } catch (error: any) {
-        this.metrics.incrementFailed('storage_failed')
-        this.logger.logError(error?.message || error)
-        results.push({ success: false, error: error?.message || error })
-      }
-    }
-    this.logger.logInfo('Webhook batch processed', { count: results.length })
-    return results
+    return this.eventsService.processEventsBatch(eventPayloads, correlationId)
   }
 } 

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -9,6 +9,7 @@ import { LoggerModule } from '../../common/services/logger.module'
 import { NatsModule } from '../nats/nats.module'
 import { EventStorageService } from './services/event-storage.service'
 import { EventDispatcherService } from './services/event-dispatcher.service'
+import { DeadLetterQueueService } from './services/dead-letter-queue.service'
 
 @Module({
   imports: [MetricsModule, LoggerModule, HealthModule, NatsModule],
@@ -19,7 +20,8 @@ import { EventDispatcherService } from './services/event-dispatcher.service'
     NatsPublisher,
     EventStorageService,
     EventDispatcherService,
+    DeadLetterQueueService,
   ],
-  exports: [EventsService, EventStorageService, EventDispatcherService],
+  exports: [EventsService, EventStorageService, EventDispatcherService, DeadLetterQueueService],
 })
 export class EventsModule {} 

--- a/src/modules/events/services/dead-letter-queue.service.ts
+++ b/src/modules/events/services/dead-letter-queue.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common'
+import * as fs from 'fs/promises'
+import { createWriteStream, existsSync } from 'fs'
+import * as readline from 'readline'
+
+const DLQ_PATH = process.env.DLQ_PATH || './data/dead_letter_queue.jsonl'
+
+@Injectable()
+export class DeadLetterQueueService {
+  async saveChunk(chunk: unknown[]): Promise<void> {
+    const stream = createWriteStream(DLQ_PATH, { flags: 'a' })
+    for (const event of chunk) {
+      stream.write(JSON.stringify(event) + '\n')
+    }
+    await new Promise((resolve, reject) => {
+      stream.on('error', reject)
+      stream.end(resolve)
+    })
+  }
+
+  async getAll(): Promise<unknown[]> {
+    if (!existsSync(DLQ_PATH)) return []
+    const fileContent = await fs.readFile(DLQ_PATH, 'utf-8')
+    return fileContent
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line))
+  }
+} 

--- a/src/modules/events/services/dead-letter-queue.service.ts
+++ b/src/modules/events/services/dead-letter-queue.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import * as fs from 'fs/promises'
 import { createWriteStream, existsSync } from 'fs'
-import * as readline from 'readline'
 
 const DLQ_PATH = process.env.DLQ_PATH || './data/dead_letter_queue.jsonl'
 

--- a/src/modules/nats/services/nats.publisher.ts
+++ b/src/modules/nats/services/nats.publisher.ts
@@ -130,15 +130,14 @@ export class NatsPublisher implements OnModuleInit, OnModuleDestroy {
     correlationId?: string
   ) {
     await this.readyPromise
-    const results = await Promise.all(
-      events.map(async (event) => {
-        try {
-          return await this.publish(baseTopic, event, correlationId)
-        } catch (err) {
-          return { success: false, error: err instanceof Error ? err.message : err, event }
-        }
-      })
-    )
-    return results
+    return await Promise.all(
+          events.map(async (event) => {
+            try {
+              return await this.publish(baseTopic, event, correlationId)
+            } catch (err) {
+              return { success: false, error: err instanceof Error ? err.message : err, event }
+            }
+          })
+        );
   }
 } 

--- a/src/modules/nats/services/nats.publisher.ts
+++ b/src/modules/nats/services/nats.publisher.ts
@@ -123,4 +123,22 @@ export class NatsPublisher implements OnModuleInit, OnModuleDestroy {
       await (client as Closable).close()
     }
   }
+
+  async batchPublish(
+    baseTopic: string,
+    events: { eventType: string }[],
+    correlationId?: string
+  ) {
+    await this.readyPromise
+    const results = await Promise.all(
+      events.map(async (event) => {
+        try {
+          return await this.publish(baseTopic, event, correlationId)
+        } catch (err) {
+          return { success: false, error: err instanceof Error ? err.message : err, event }
+        }
+      })
+    )
+    return results
+  }
 } 

--- a/tests/events/event.service.spec.ts
+++ b/tests/events/event.service.spec.ts
@@ -22,6 +22,7 @@ describe('EventsService', () => {
   let loggerService: LoggerService;
   let prisma: { event: { create: jest.Mock } };
   let correlationIdService: { runWithId: (id: string, fn: any) => any; getId: () => string };
+  let dlq: DeadLetterQueueService;
 
   beforeEach(() => {
     register.clear();
@@ -33,13 +34,14 @@ describe('EventsService', () => {
     };
     loggerService = new LoggerService({ get: jest.fn() } as any, correlationIdService as any);
     prisma = { event: { create: jest.fn() } };
+    dlq = { saveChunk: jest.fn() } as any;
     jest.spyOn(metricsService, 'incrementAccepted').mockImplementation(jest.fn());
     jest.spyOn(metricsService, 'incrementFailed').mockImplementation(jest.fn());
     jest.spyOn(metricsService, 'observeProcessingTime').mockImplementation(jest.fn());
     jest.spyOn(loggerService, 'logInfo').mockImplementation(jest.fn());
     jest.spyOn(loggerService, 'logEvent').mockImplementation(jest.fn());
     jest.spyOn(loggerService, 'logError').mockImplementation(jest.fn());
-    service = new EventsService(loggerService, natsPublisher as any, metricsService, prisma as any, correlationIdService as any);
+    service = new EventsService(loggerService, natsPublisher as any, metricsService, prisma as any, correlationIdService as any, dlq);
   });
 
   it('should process event successfully', async () => {

--- a/tests/events/event.service.spec.ts
+++ b/tests/events/event.service.spec.ts
@@ -2,6 +2,7 @@ import { EventsService } from '../../src/modules/events/services/event.service';
 import { LoggerService } from '../../src/common/services/logger.service';
 import { MetricsService } from '../../src/modules/metrics/services/metrics.service';
 import { register } from 'prom-client';
+import { DeadLetterQueueService } from '../../src/modules/events/services/dead-letter-queue.service'
 
 class MockPrismaClientKnownRequestError extends Error {
   code: string;
@@ -140,4 +141,56 @@ describe('EventsService', () => {
     expect(result).toEqual({ success: true, alreadyProcessed: true, correlationId: 'corr-unique' });
     expect(natsPublisher.publish).not.toHaveBeenCalled();
   });
-}); 
+});
+
+describe('EventsService batch processing', () => {
+  let service: EventsService
+  let prisma: any
+  let nats: any
+  let dlq: any
+
+  beforeEach(() => {
+    prisma = { event: { createMany: jest.fn() } }
+    nats = { batchPublish: jest.fn() }
+    dlq = { saveChunk: jest.fn() }
+    service = new EventsService(
+      { logError: jest.fn(), logEvent: jest.fn(), logInfo: jest.fn() } as any,
+      nats,
+      { incrementFailed: jest.fn(), incrementAccepted: jest.fn(), observeProcessingTime: jest.fn() } as any,
+      prisma,
+      { getId: jest.fn() } as any,
+      dlq
+    )
+  })
+
+  it('should batch insert and publish events', async () => {
+    prisma.event.createMany.mockResolvedValue({})
+    nats.batchPublish.mockResolvedValue([{ success: true }])
+    const events = [
+      { source: 'facebook', eventId: '1', timestamp: new Date().toISOString(), funnelStage: 'top', eventType: 'ad.view', data: { user: { userId: 'u1', name: 'n', age: 1, gender: 'male', location: { country: 'c', city: 'c' } }, engagement: { actionTime: 't', referrer: 'newsfeed', videoId: null } } },
+      { source: 'facebook', eventId: '2', timestamp: new Date().toISOString(), funnelStage: 'top', eventType: 'ad.view', data: { user: { userId: 'u2', name: 'n', age: 1, gender: 'male', location: { country: 'c', city: 'c' } }, engagement: { actionTime: 't', referrer: 'newsfeed', videoId: null } } }
+    ]
+    const res = await service.processEventsBatch(events)
+    expect(prisma.event.createMany).toHaveBeenCalled()
+    expect(nats.batchPublish).toHaveBeenCalled()
+    expect(res.some(r => r.success)).toBeTruthy()
+  })
+
+  it('should save chunk to DLQ on error', async () => {
+    prisma.event.createMany.mockRejectedValue(new Error('db error'))
+    const events = [
+      { source: 'facebook', eventId: '1', timestamp: new Date().toISOString(), funnelStage: 'top', eventType: 'ad.view', data: { user: { userId: 'u1', name: 'n', age: 1, gender: 'male', location: { country: 'c', city: 'c' } }, engagement: { actionTime: 't', referrer: 'newsfeed', videoId: null } } }
+    ]
+    await service.processEventsBatch(events)
+    expect(dlq.saveChunk).toHaveBeenCalled()
+  })
+
+  it('should return invalid results for invalid events', async () => {
+    const events = [
+      { invalid: true }
+    ]
+    const res = await service.processEventsBatch(events)
+    expect(res[0].success).toBe(false)
+    expect(res[0].error).toBeDefined()
+  })
+}) 

--- a/tests/events/events.controller.spec.ts
+++ b/tests/events/events.controller.spec.ts
@@ -6,7 +6,7 @@ import { HealthService } from '../../src/modules/health/services/health.service'
 
 describe('EventsController', () => {
   let controller: EventsController;
-  let eventsService: { processEvent: jest.Mock, processEvents: jest.Mock };
+  let eventsService: { processEvent: jest.Mock, processEvents: jest.Mock, processEventsBatch: jest.Mock };
   let logger: LoggerService;
   let metrics: MetricsService;
   let healthService: HealthService;
@@ -15,7 +15,7 @@ describe('EventsController', () => {
 
   beforeEach(() => {
     register.clear();
-    eventsService = { processEvent: jest.fn(), processEvents: jest.fn() };
+    eventsService = { processEvent: jest.fn(), processEvents: jest.fn(), processEventsBatch: jest.fn() };
     correlationIdService = { getId: jest.fn().mockReturnValue('test-cid') } as any;
     logger = new LoggerService({ get: jest.fn() } as any, correlationIdService as any);
     metrics = new MetricsService() as any;

--- a/tests/events/events.controller.spec.ts
+++ b/tests/events/events.controller.spec.ts
@@ -56,18 +56,17 @@ describe('EventsController', () => {
         },
       },
     }
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ success: true }])
     const result = await controller.handleWebhook([validEvent])
     expect(result).toEqual([{ success: true }])
-    expect(eventStorage.add).toHaveBeenCalledWith(validEvent)
-    expect(metrics.incrementAccepted).toHaveBeenCalledWith(validEvent.source, validEvent.funnelStage, validEvent.eventType)
   })
 
   it('should handle invalid payload', async () => {
     const invalidEvent = { foo: 'bar' }
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ success: false, error: 'Invalid payload' }])
     const result = await controller.handleWebhook([invalidEvent])
     expect(result[0].success).toBe(false)
     expect(result[0].error).toBeDefined()
-    expect(metrics.incrementFailed).toHaveBeenCalledWith('validation_failed')
   })
 
   it('should handle storage error', async () => {
@@ -92,11 +91,10 @@ describe('EventsController', () => {
         },
       },
     }
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ success: false, error: 'fail' }])
     eventStorage.add.mockRejectedValue(new Error('fail'))
     const result = await controller.handleWebhook([validEvent])
     expect(result).toEqual([{ success: false, error: 'fail' }])
-    expect(metrics.incrementFailed).toHaveBeenCalledWith('storage_failed')
-    expect(logger.logError).toHaveBeenCalled()
   })
 
   it('should return 503 if service is shutting down', async () => {
@@ -124,7 +122,7 @@ describe('EventsController', () => {
         }
       }
     ])).rejects.toThrow('Service is shutting down');
-    expect(eventsService.processEvents).not.toHaveBeenCalled();
+    expect(eventsService.processEventsBatch).not.toHaveBeenCalled();
   });
 
   it('should add valid events and return success statuses', async () => {
@@ -150,19 +148,17 @@ describe('EventsController', () => {
         },
       },
     };
-    eventsService.processEvents.mockResolvedValueOnce([{ success: true }]);
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ success: true }]);
     const result = await controller.handleWebhook([validEvent]);
     expect(result).toEqual([{ success: true }]);
-    expect(eventStorage.add).toHaveBeenCalledWith(validEvent);
-    expect(metrics.incrementAccepted).toHaveBeenCalled();
   });
 
   it('should return error status for invalid event', async () => {
     const invalidEvent = { foo: 'bar' };
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ error: 'Invalid', success: false }]);
     await expect(controller.handleWebhook([invalidEvent])).resolves.toEqual([
       { error: expect.anything(), success: false }
     ]);
-    expect(metrics.incrementFailed).toHaveBeenCalledWith('validation_failed');
   });
 
   it('should return error status for storage error', async () => {
@@ -187,36 +183,9 @@ describe('EventsController', () => {
         },
       },
     };
+    eventsService.processEventsBatch.mockResolvedValueOnce([{ error: 'fail', success: false }]);
     eventStorage.add.mockRejectedValue(new Error('fail'));
     const result = await controller.handleWebhook([validEvent]);
     expect(result).toEqual([{ success: false, error: 'fail' }]);
-    expect(metrics.incrementFailed).toHaveBeenCalledWith('storage_failed');
-    expect(logger.logError).toHaveBeenCalled();
-  });
-
-  it('should return 503 if service is shutting down', async () => {
-    (healthService.isShuttingDownNow as jest.Mock).mockReturnValue(true);
-    await expect(controller.handleWebhook([{
-      eventId: '1',
-      timestamp: new Date().toISOString(),
-      source: 'facebook',
-      funnelStage: 'top',
-      eventType: 'ad.view',
-      data: {
-        user: {
-          userId: 'u1',
-          name: 'John Doe',
-          age: 30,
-          gender: 'male',
-          location: { country: 'USA', city: 'NY' }
-        },
-        engagement: {
-          actionTime: new Date().toISOString(),
-          referrer: 'newsfeed',
-          videoId: null
-        }
-      }
-    }])).rejects.toThrow('Service is shutting down');
-    expect(eventStorage.add).not.toHaveBeenCalled();
   });
 }); 


### PR DESCRIPTION
## Summary by Sourcery

Introduce batch processing for events with validation, chunking, and error handling backed by a dead-letter queue.

New Features:
- Add processEventsBatch in EventsService to validate, chunk, bulk-insert, and publish events.
- Implement DeadLetterQueueService to persist failed event batches to a JSONL file.
- Add batchPublish to NatsPublisher to concurrently publish multiple events with per-event success tracking.

Enhancements:
- Refactor EventsController to delegate webhook handling to processEventsBatch instead of manual validation and storage.
- Register DeadLetterQueueService in EventsModule and inject it into EventsService.
- Use Zod schema for event payload validation in batch processing.

Tests:
- Add unit tests for batch insertion, publishing, invalid payload handling, and DLQ saving.
- Update existing EventService and EventsController tests to inject and verify DeadLetterQueueService and processEventsBatch usage.